### PR TITLE
修改epid代码

### DIFF
--- a/epid_role/epid.cpp
+++ b/epid_role/epid.cpp
@@ -11,35 +11,65 @@ PFC pfc(AES_SECURITY);
 
 int main()
 {
-    miracl *mip = get_mip();
-    time_t seed;
+    // miracl *mip = get_mip();
+    // time_t seed;
 
-    //GPK *gpk = (GPK *)malloc(sizeof(GPK));   
     GPK *gpk = new GPK(); 
-    PRL *pRL = new PRL();
-    SRL *sRL = new SRL();
+    PPK *ppk = new PPK();
 
-    time(&seed);
-    irand((long)seed);
+    Public_PRL *pRL = new Public_PRL();
+    Public_SRL *sRL = new Public_SRL();
+
+    // time(&seed);
+    // irand((long)seed);
 
     printf("Setup..\n");
     issuerSetup(gpk);
     platformPreCom();
     verifierPreCom();
-    revokerPreCom();
+    revokerPreCom(pRL,sRL);
 
-    // Join
-    cout << "Join" << endl;
-    CommC *commC = platformJoin_1(gpk);
-    CRE *cre = issuerJoin_2(gpk, commC);
-    PPK *ppk = platformJoin_3(gpk, cre);
+// Join
+    cout << "Join.." << endl;
+    Platform_CommC *platformCommC = new Platform_CommC();
+    Issuer_CommC *issuerCommC;
 
-    // Sign
-    cout << "Sign" << endl;
+    Issuer_CRE *issuerCre = new Issuer_CRE();
+    Platform_CRE *platformCre;
+
+    
+
+    // platform 生成 platformCommC
+    platformJoin_1(gpk,platformCommC);
+    // platform 发送 platformCommC 给 issuer
+    // issuer 用 IssuerCommC 接收
+    issuerCommC = (Issuer_CommC*)platformCommC;
+
+    // issuer 生成 Issuer_CRE
+    issuerJoin_2(gpk, issuerCommC, issuerCre);
+    // issuer 发送 issuerCre 给 platform
+    // platform 用 platformCre 接收
+    platformCre = (Platform_CRE*)issuerCre;
+
+    // 平台生成公私钥
+    if(platformJoin_3(gpk, platformCre, ppk)) exit(0);
+
+// Sign
+    cout << "Sign.." << endl;
     char m[] = "Test message to be signed";
-    Sigma *sigma = platformSign(gpk, m, sRL);
+    Platform_Sigma *platformSigma = new Platform_Sigma();
+    platformSigma->sigma0 = new Platform_Sigma0();
+    platformSigma->sigmai = new Platform_Sigmai();
+    platformSigma->sigmai->cnt = sRL->cnt;
+    platformSigma->sigmai->sigmai = new Platform_BK_SPK[sRL->cnt];
 
-    // Verify
-    cout << "Verify" << endl;
-    verifierVerify(gpk, m, pRL, sigma->sigmai, sigma->sigma0);
+    platformSign(gpk, m, sRL, platformSigma);
+
+    // platform 发送 platformSigma 给 verifier
+    // verifier 用 verifierSigma 接收，之后需要添加上m
+    Verifier_Sigma *verifierSigma = (Verifier_Sigma*) platformSigma;
+
+// Verify
+    cout << "Verify.." << endl;
+    if(verifierVerify(gpk, m, pRL, verifierSigma->sigmai, verifierSigma->sigma0)) exit(0);
 }

--- a/epid_role/epid_fail_test.cpp
+++ b/epid_role/epid_fail_test.cpp
@@ -1,0 +1,226 @@
+#include <iostream>
+#include <ctime>
+
+#include "epid_type.h"
+#include "epid_issuer.h"
+#include "epid_platform.h"
+#include "epid_revoker.h"
+#include "epid_verifier.h"
+
+PFC pfc(AES_SECURITY);
+
+void failTest_1(){
+    cout << "【fail-test 1】: change message" << endl;
+    GPK *gpk = new GPK(); 
+    PPK *ppk = new PPK();
+
+    Public_PRL *pRL = new Public_PRL();
+    Public_SRL *sRL = new Public_SRL();
+
+
+    printf("Setup..\n");
+    issuerSetup(gpk);
+    platformPreCom();
+    verifierPreCom();
+    revokerPreCom(pRL,sRL);
+
+// Join
+    cout << "Join.." << endl;
+    Platform_CommC *platformCommC = new Platform_CommC();
+    Issuer_CommC *issuerCommC;
+
+    Issuer_CRE *issuerCre = new Issuer_CRE();
+    Platform_CRE *platformCre;
+
+    // platform 生成 platformCommC
+    platformJoin_1(gpk,platformCommC);
+    // platform 发送 platformCommC 给 issuer
+    // issuer 用 IssuerCommC 接收
+    issuerCommC = (Issuer_CommC*)platformCommC;
+
+    // issuer 生成 Issuer_CRE
+    issuerJoin_2(gpk, issuerCommC, issuerCre);
+    // issuer 发送 issuerCre 给 platform
+    // platform 用 platformCre 接收
+    platformCre = (Platform_CRE*)issuerCre;
+
+    // 平台生成公私钥
+    if(platformJoin_3(gpk, platformCre, ppk)) exit(0);
+// change message.. 
+// Sign
+    cout << "Sign.." << endl;
+    char m[] = "Test message to be signed";
+
+    Platform_Sigma *platformSigma = new Platform_Sigma();
+    platformSigma->sigma0 = new Platform_Sigma0();
+    platformSigma->sigmai = new Platform_Sigmai();
+    platformSigma->sigmai->cnt = sRL->cnt;
+    platformSigma->sigmai->sigmai = new Platform_BK_SPK[sRL->cnt];
+
+    platformSign(gpk, m, sRL, platformSigma);
+    cout << "m: \"" << m <<"\"";
+    m[0] = 't';
+    cout<<" is changed into: \""<<m<<"\""<<endl;
+
+// Verify
+    cout << "Verify.." << endl;
+    Verifier_Sigma *verifierSigma = (Verifier_Sigma*)platformSigma;
+    verifierVerify(gpk, m, pRL, verifierSigma->sigmai, verifierSigma->sigma0);
+}
+
+void failTest_2(){
+    cout << "【fail-test 2】: revoke in sRL" << endl;
+    GPK *gpk = new GPK(); 
+    PPK *ppk = new PPK();
+
+    Public_PRL *pRL = new Public_PRL();
+    Public_SRL *sRL = new Public_SRL();
+
+
+    printf("Setup..\n");
+    issuerSetup(gpk);
+    platformPreCom();
+    verifierPreCom();
+    revokerPreCom(pRL,sRL);
+
+// Join
+    cout << "Join.." << endl;
+    Platform_CommC *platformCommC = new Platform_CommC();
+    Issuer_CommC *issuerCommC;
+
+    Issuer_CRE *issuerCre = new Issuer_CRE();
+    Platform_CRE *platformCre;
+
+    // platform 生成 platformCommC
+    platformJoin_1(gpk,platformCommC);
+    // platform 发送 platformCommC 给 issuer
+    // issuer 用 IssuerCommC 接收
+    issuerCommC = (Issuer_CommC*)platformCommC;
+
+    // issuer 生成 Issuer_CRE
+    issuerJoin_2(gpk, issuerCommC, issuerCre);
+    // issuer 发送 issuerCre 给 platform
+    // platform 用 platformCre 接收
+    platformCre = (Platform_CRE*)issuerCre;
+
+    // 平台生成公私钥
+    if(platformJoin_3(gpk, platformCre, ppk)) exit(0);
+// revoke in sRL
+// Sign
+    cout << "Original Sign.." << endl;
+    char m[] = "Test message to be signed";
+
+    Platform_Sigma *platformSigma = new Platform_Sigma();
+    platformSigma->sigma0 = new Platform_Sigma0();
+    platformSigma->sigmai = new Platform_Sigmai();
+    platformSigma->sigmai->cnt = sRL->cnt;
+    platformSigma->sigmai->sigmai = new Platform_BK_SPK[sRL->cnt];
+
+    platformSign(gpk, m, sRL, platformSigma);
+
+// Verify
+    cout << "Original Verify.." << endl;
+    Verifier_Sigma *verifierSigma = (Verifier_Sigma*)platformSigma;
+    verifierVerify(gpk, m, pRL, verifierSigma->sigmai, verifierSigma->sigma0);
+
+// sRL 撤销
+    cout << "revoke in sRL.. "<<endl;
+    Revoker_Sigma *revokerSigma = (Revoker_Sigma*)platformSigma;
+    revokerRevokeSRL(gpk,pRL,sRL,m,revokerSigma);//里面有一次验证
+
+// 再次签名
+    cout << "Test Sign.." << endl;
+    char tm[] = "Test message to be signed";
+    Platform_Sigma *platformSigmaTest = new Platform_Sigma();
+    platformSigmaTest->sigma0 = new Platform_Sigma0();
+    platformSigmaTest->sigmai = new Platform_Sigmai();
+    platformSigmaTest->sigmai->cnt = sRL->cnt;
+    platformSigmaTest->sigmai->sigmai = new Platform_BK_SPK[sRL->cnt];
+
+    platformSign(gpk, tm, sRL, platformSigmaTest);
+
+// Verify
+    cout << "Test Verify.." << endl;
+    Verifier_Sigma *verifierSigmaTest = (Verifier_Sigma*)platformSigmaTest;
+    verifierVerify(gpk, tm, pRL, verifierSigmaTest->sigmai, verifierSigmaTest->sigma0);
+
+}
+
+void failTest_3(){
+    cout << "【fail-test 3】: revoke in pRL" << endl;
+    GPK *gpk = new GPK(); 
+    PPK *ppk = new PPK();
+
+    Public_PRL *pRL = new Public_PRL();
+    Public_SRL *sRL = new Public_SRL();
+
+
+    printf("Setup..\n");
+    issuerSetup(gpk);
+    platformPreCom();
+    verifierPreCom();
+    revokerPreCom(pRL,sRL);
+
+// Join
+    cout << "Join.." << endl;
+    Platform_CommC *platformCommC = new Platform_CommC();
+    Issuer_CommC *issuerCommC;
+
+    Issuer_CRE *issuerCre = new Issuer_CRE();
+    Platform_CRE *platformCre;
+
+    // platform 生成 platformCommC
+    platformJoin_1(gpk,platformCommC);
+    // platform 发送 platformCommC 给 issuer
+    // issuer 用 IssuerCommC 接收
+    issuerCommC = (Issuer_CommC*)platformCommC;
+
+    // issuer 生成 Issuer_CRE
+    issuerJoin_2(gpk, issuerCommC, issuerCre);
+    // issuer 发送 issuerCre 给 platform
+    // platform 用 platformCre 接收
+    platformCre = (Platform_CRE*)issuerCre;
+
+    // 平台生成公私钥
+    if(platformJoin_3(gpk, platformCre, ppk)) exit(0);
+
+// revoke in pRL
+    Revoker_SK* sk_revoker = (Revoker_SK*)platformLeakSK_Test();
+    cout << "Leak the sk: " << sk_revoker << endl;
+    cout << "revoke in pRL.. " <<endl;
+    revokerRevokePRL(gpk,pRL,sk_revoker);
+
+// Sign
+    cout << "Sign.." << endl;
+    char m[] = "Test message to be signed";
+    Platform_Sigma *platformSigma = new Platform_Sigma();
+    platformSigma->sigma0 = new Platform_Sigma0();
+    platformSigma->sigmai = new Platform_Sigmai();
+    platformSigma->sigmai->cnt = sRL->cnt;
+    platformSigma->sigmai->sigmai = new Platform_BK_SPK[sRL->cnt];
+
+    platformSign(gpk, m, sRL, platformSigma);
+
+
+// Verify
+    cout << "Verify.." << endl;
+    Verifier_Sigma* verifierSigma = (Verifier_Sigma*)platformSigma;
+    verifierVerify(gpk, m, pRL, verifierSigma->sigmai, verifierSigma->sigma0);
+}
+
+int main(){
+    // miracl *mip = get_mip();
+    // time_t seed;
+
+    // time(&seed);
+    // irand((long)seed);
+
+
+// fail_test1:改变消息内容
+    failTest_1();
+// fail_test2:pRL撤销后签名
+    failTest_2();
+// fail_test3:签名后sRL撤销，再次签名
+    failTest_3();
+
+}

--- a/epid_role/epid_issuer.cpp
+++ b/epid_role/epid_issuer.cpp
@@ -1,31 +1,33 @@
 #include "epid_issuer.h"
 
 Big isk;
+PFC *issuerPFC= &pfc;
+
 
 void issuerSetup(GPK *gpk){
-    gpk->p = pfc.order();
-    pfc.random(gpk->g1);
-    pfc.random(gpk->g2);
-    pfc.random(gpk->g3);
-    pfc.random(isk);
-    pfc.random(gpk->h1);
-    pfc.random(gpk->h2);
-    gpk->w=pfc.mult(gpk->g2, isk);
+    // issuerPFC = PFC(AES_SECURITY);
 
-    pfc.precomp_for_mult(gpk->g1);
-    pfc.precomp_for_mult(gpk->g2);
-    pfc.precomp_for_mult(gpk->g3);
-    pfc.precomp_for_mult(gpk->h1);
-    pfc.precomp_for_mult(gpk->h2);
-    pfc.precomp_for_mult(gpk->w);
-    pfc.precomp_for_pairing(gpk->g2);
+    gpk->p = issuerPFC->order();
+    issuerPFC->random(gpk->g1);
+    issuerPFC->random(gpk->g2);
+    issuerPFC->random(gpk->g3);
+    issuerPFC->random(isk);
+    issuerPFC->random(gpk->h1);
+    issuerPFC->random(gpk->h2);
+    gpk->w=issuerPFC->mult(gpk->g2, isk);
+
+    issuerPFC->precomp_for_mult(gpk->g1);
+    issuerPFC->precomp_for_mult(gpk->g2);
+    issuerPFC->precomp_for_mult(gpk->g3);
+    issuerPFC->precomp_for_mult(gpk->h1);
+    issuerPFC->precomp_for_mult(gpk->h2);
+    issuerPFC->precomp_for_mult(gpk->w);
+    issuerPFC->precomp_for_pairing(gpk->g2);
 }
 
-CRE* issuerJoin_2(GPK *gpk, CommC *commC){
+void issuerJoin_2(GPK *gpk, Issuer_CommC *commC, Issuer_CRE* cre){
     //CRE *cre = (CRE*)malloc(sizeof(CRE));
-    CRE *cre = new CRE();
-    pfc.random(cre->x);
-    pfc.random(cre->y2);
-    cre->A = pfc.mult(gpk->g1+commC->C+pfc.mult(gpk->h2, cre->y2),inverse(cre->x+isk,gpk->p));
-    return cre;
+    issuerPFC->random(cre->x);
+    issuerPFC->random(cre->y2);
+    cre->A = issuerPFC->mult(gpk->g1+commC->C+issuerPFC->mult(gpk->h2, cre->y2),inverse(cre->x+isk,gpk->p));
 }

--- a/epid_role/epid_issuer.h
+++ b/epid_role/epid_issuer.h
@@ -1,13 +1,25 @@
 #ifndef EPID_ISSUER
 #define EPID_ISSUER
 
-#define MR_PAIRING_BN    // AES-128 or AES-192 security
-#define AES_SECURITY 128
+// #define MR_PAIRING_BN    // AES-128 or AES-192 security
+// #define AES_SECURITY 128
 
-#include "pairing_3.h"
+// #include "pairing_3.h"
 #include "epid_type.h"
 
+// platform & issuer
+struct Issuer_CommC{
+    G1 C;
+    Big c,sf,sy1;
+};
+
+// platform & issuer
+struct Issuer_CRE{
+    G1 A;
+    Big x,y2;
+};
+
 void issuerSetup(GPK *gpk);
-CRE* issuerJoin_2(GPK *gpk, CommC *commC);
+void issuerJoin_2(GPK *gpk, Issuer_CommC *commC, Issuer_CRE* cre);
 
 #endif

--- a/epid_role/epid_platform.cpp
+++ b/epid_role/epid_platform.cpp
@@ -4,204 +4,180 @@ GT pt1,pt2,pt3,pt4;
 SK *sk;//sk
 Big y_1;
 
+PFC *platformPFC=&pfc;
+
 void platformPreCom()
 {
-    pfc.precomp_for_power(pt1);
-    pfc.precomp_for_power(pt2);
-    pfc.precomp_for_power(pt3);
-    pfc.precomp_for_power(pt4);
+    // platformPFC = PFC(AES_SECURITY);
+    platformPFC->precomp_for_power(pt1);
+    platformPFC->precomp_for_power(pt2);
+    platformPFC->precomp_for_power(pt3);
+    platformPFC->precomp_for_power(pt4);
 }
 
-CommC *platformJoin_1(GPK *gpk)
+void platformJoin_1(GPK *gpk, Platform_CommC* commC)
 {
     Big f;
-    pfc.random(f);
-    pfc.random(y_1);
+    platformPFC->random(f);
+    platformPFC->random(y_1);
 
     // C的知识证明
     // CommC *commC = (CommC *)malloc(sizeof(CommC));
-    CommC *commC = new CommC();
-    commC->C = pfc.mult(gpk->h1, f) + pfc.mult(gpk->h2, y_1);
+    commC->C = platformPFC->mult(gpk->h1, f) + platformPFC->mult(gpk->h2, y_1);
     Big rf, ry1, c;
     G1 PoC;
-    pfc.random(rf);
-    pfc.random(ry1);
-    PoC = pfc.mult(gpk->h1, rf) + pfc.mult(gpk->h2, ry1);
+    platformPFC->random(rf);
+    platformPFC->random(ry1);
+    PoC = platformPFC->mult(gpk->h1, rf) + platformPFC->mult(gpk->h2, ry1);
     // 计算c的哈希值，暂时只用一些参数，需要与证明的对应
-    pfc.start_hash();
-    pfc.add_to_hash(gpk->p);
-    pfc.add_to_hash(gpk->h1);
-    pfc.add_to_hash(gpk->h2);
-    pfc.add_to_hash(commC->C);
-    pfc.add_to_hash(PoC);
-    c = pfc.finish_hash_to_group();
+    platformPFC->start_hash();
+    platformPFC->add_to_hash(gpk->p);
+    platformPFC->add_to_hash(gpk->h1);
+    platformPFC->add_to_hash(gpk->h2);
+    platformPFC->add_to_hash(commC->C);
+    platformPFC->add_to_hash(PoC);
+    c = platformPFC->finish_hash_to_group();
 
-    // sk = (SK *)malloc(sizeof(SK));
     sk = new SK();
     sk->f = f;
 
     commC->sf = (rf + modmult(c, f, gpk->p)) % gpk->p;
     commC->sy1 = (ry1 + modmult(c, y_1, gpk->p)) % gpk->p;
     commC->c = c;
-
-    return commC;
 }
 
-PPK *platformJoin_3(GPK *gpk, CRE *cre)
+int platformJoin_3(GPK *gpk, Platform_CRE *cre, PPK *pk)
 {
     Big y = (y_1 + cre->y2) % gpk->p;
     // pairing验证
-    G2 wxg2 = gpk->w + pfc.mult(gpk->g2, cre->x);
-    G1 g1h1fh2y = -(pfc.mult(gpk->h1, sk->f) + pfc.mult(gpk->h2, y) + gpk->g1);
+    G2 wxg2 = gpk->w + platformPFC->mult(gpk->g2, cre->x);
+    G1 g1h1fh2y = -(platformPFC->mult(gpk->h1, sk->f) + platformPFC->mult(gpk->h2, y) + gpk->g1);
     G1 *e1[2];
     G2 *e2[2];
     e1[0] = &cre->A;
     e1[1] = &g1h1fh2y;
     e2[0] = &wxg2;
     e2[1] = &gpk->g2;
-    if (pfc.multi_pairing(2, e2, e1) != 1)
+    if (platformPFC->multi_pairing(2, e2, e1) != 1)
     {
         cout << "Pairing verification failed, aborting.. " << endl;
-        exit(0);
+        return -1;
     }
 
     sk->A = cre->A;
     sk->x = cre->x;
     sk->y = y;
 
-    // PPK *pk = (PPK *)malloc(sizeof(PPK));
-    PPK *pk = new PPK();
     pk->A = cre->A;
     pk->x = cre->x;
     pk->y = y;
 
-    return pk;
+    return 0;
 }
 
-Sigma *platformSign(GPK *gpk, char *m, SRL *sRL)
+void platformSign(GPK *gpk, char *m, Public_SRL *sRL, Platform_Sigma* sigma)
 {
     G3 B, K, R1;
     G1 T;
     GT R2;
     Big a, b;
 
-    pfc.random(B);
-    K = pfc.mult(B, sk->f);
-    pfc.random(a);
+    platformPFC->random(B);
+    K = platformPFC->mult(B, sk->f);
+    platformPFC->random(a);
     b = sk->y + modmult(a, sk->x, gpk->p) % gpk->p;
-    T = sk->A + pfc.mult(gpk->h2, a);
+    T = sk->A + platformPFC->mult(gpk->h2, a);
 
     // 生成sigma0的知识证明
     Big rx, rf, ra, rb, c;
     Big sx, sf, sa, sb;
-    pfc.random(rx);
-    pfc.random(rf);
-    pfc.random(ra);
-    pfc.random(rb);
-    R1 = pfc.mult(B, rf);
-    R2 = pfc.power(pfc.pairing(gpk->g2, sk->A), -rx) * pfc.power(pt2, rf) * pfc.power(pt3, rb - modmult(a, rx, gpk->p) % gpk->p) * pfc.power(pt4, ra);
-    pfc.start_hash();
-    pfc.add_to_hash(gpk->p);
-    pfc.add_to_hash(gpk->g1);
-    pfc.add_to_hash(gpk->g2);
-    pfc.add_to_hash(gpk->g3);
-    pfc.add_to_hash(gpk->h1);
-    pfc.add_to_hash(gpk->h2);
-    pfc.add_to_hash(gpk->w);
-    pfc.add_to_hash(B);
-    pfc.add_to_hash(K);
-    pfc.add_to_hash(T);
-    pfc.add_to_hash(R1);
-    pfc.add_to_hash(R2);
-    pfc.add_to_hash(m);
-    c = pfc.finish_hash_to_group();
+    platformPFC->random(rx);
+    platformPFC->random(rf);
+    platformPFC->random(ra);
+    platformPFC->random(rb);
+    R1 = platformPFC->mult(B, rf);
+    R2 = platformPFC->power(platformPFC->pairing(gpk->g2, sk->A), -rx) * platformPFC->power(pt2, rf) * platformPFC->power(pt3, rb - modmult(a, rx, gpk->p) % gpk->p) * platformPFC->power(pt4, ra);
+    platformPFC->start_hash();
+    platformPFC->add_to_hash(gpk->p);
+    platformPFC->add_to_hash(gpk->g1);
+    platformPFC->add_to_hash(gpk->g2);
+    platformPFC->add_to_hash(gpk->g3);
+    platformPFC->add_to_hash(gpk->h1);
+    platformPFC->add_to_hash(gpk->h2);
+    platformPFC->add_to_hash(gpk->w);
+    platformPFC->add_to_hash(B);
+    platformPFC->add_to_hash(K);
+    platformPFC->add_to_hash(T);
+    platformPFC->add_to_hash(R1);
+    platformPFC->add_to_hash(R2);
+    platformPFC->add_to_hash(m);
+    c = platformPFC->finish_hash_to_group();
     sx = (rx + modmult(c, sk->x, gpk->p)) % gpk->p;
     sa = (ra + modmult(c, a, gpk->p)) % gpk->p;
     sb = (rb + modmult(c, b, gpk->p)) % gpk->p;
     sf = (rf + modmult(c, sk->f, gpk->p)) % gpk->p;
 
-    // Sigma0 *sigma0 = (Sigma0 *)malloc(sizeof(Sigma0));
-    Sigma0 *sigma0 = new Sigma0();
 
-    sigma0->B = B;
-    sigma0->K = K;
-    sigma0->c = c;
-    sigma0->T = T;
-    sigma0->sa = sa;
-    sigma0->sx = sx;
-    sigma0->sb = sb;
-    sigma0->sf = sf;
+    sigma->sigma0->B = B;
+    sigma->sigma0->K = K;
+    sigma->sigma0->c = c;
+    sigma->sigma0->T = T;
+    sigma->sigma0->sa = sa;
+    sigma->sigma0->sx = sx;
+    sigma->sigma0->sb = sb;
+    sigma->sigma0->sf = sf;
 
     // 生成sigmai
 
-    BK *s = sRL->head;
+    Public_SRLNode *s;
 
     // sigmai涉及到不等式进行知识证明
     // 暂时将每个不等式作为一个单独的知识证明，sigma0中已经证明了B=K^f
     // 那么sigmai就证明Ki=Bi^f，但是需要每一个都证明失败
     // Sigmai *sigmai = (Sigmai *)malloc(sizeof(Sigmai));
-    Sigmai *sigmai = new Sigmai();
 
-    while(s!=NULL)
+    for(int i=0;i<sRL->cnt;i++)
     {
-        G3 R = pfc.mult(B,rf);
-        G3 Ri = pfc.mult(s->B,rf);
-        pfc.start_hash();
-        pfc.add_to_hash(gpk->p);
-        pfc.add_to_hash(gpk->g1);
-        pfc.add_to_hash(gpk->g2);
-        pfc.add_to_hash(gpk->g3);
-        pfc.add_to_hash(gpk->h1);
-        pfc.add_to_hash(gpk->h2);
-        pfc.add_to_hash(gpk->w);
-        pfc.add_to_hash(B);
-        pfc.add_to_hash(K);
-        pfc.add_to_hash(R);
-        pfc.add_to_hash(s->B);
-        pfc.add_to_hash(s->K);
-        pfc.add_to_hash(Ri);
-        pfc.add_to_hash(m);
-        c = pfc.finish_hash_to_group();
+        s = &(sRL->sRLNode[i]);
+        G3 R = platformPFC->mult(B,rf);
+        G3 Ri = platformPFC->mult(s->B,rf);
+        platformPFC->start_hash();
+        platformPFC->add_to_hash(gpk->p);
+        platformPFC->add_to_hash(gpk->g1);
+        platformPFC->add_to_hash(gpk->g2);
+        platformPFC->add_to_hash(gpk->g3);
+        platformPFC->add_to_hash(gpk->h1);
+        platformPFC->add_to_hash(gpk->h2);
+        platformPFC->add_to_hash(gpk->w);
+        platformPFC->add_to_hash(B);
+        platformPFC->add_to_hash(K);
+        platformPFC->add_to_hash(R);
+        platformPFC->add_to_hash(s->B);
+        platformPFC->add_to_hash(s->K);
+        platformPFC->add_to_hash(Ri);
+        platformPFC->add_to_hash(m);
+        c = platformPFC->finish_hash_to_group();
 
         sf = (rf + modmult(c, sk->f, gpk->p))%gpk->p;
 
-        // BK_SPK *tmpSPK = (BK_SPK*)malloc(sizeof(BK_SPK));
-        BK_SPK *tmpSPK = new BK_SPK();
+        sigma->sigmai->sigmai[i].B = s->B;
+        sigma->sigmai->sigmai[i].K = s->K;
+        sigma->sigmai->sigmai[i].c = c;
+        sigma->sigmai->sigmai[i].sf = sf;
 
-        tmpSPK->B = s->B;
-        tmpSPK->K = s->K;
-        tmpSPK->c = c;
-        tmpSPK->sf = sf;
-
-        if(sigmai->head==NULL){
-            sigmai->head = tmpSPK;
-        }
-        else{
-            sigmai->tail->next = tmpSPK;
-        }
-        sigmai->tail = tmpSPK;
-
-        s = s->next;
     }
-    pfc.add_to_hash(m);
-
-    // Sigma *sigma = (Sigma *)malloc(sizeof(Sigma));
-    Sigma *sigma = new Sigma();
-    sigma->sigma0 = sigma0;
-    sigma->sigmai = sigmai;
-
 
     // 生成知识证明:BK用于sRL
     //  Big rbkf,cbk;
     //  Big sbkf;
     //  G3 PoK;
-    //  pfc.random(rbkf);
-    //  PoK=pfc.mult(B,rbkf);
-    //  pfc.start_hash();
-    //  pfc.add_to_hash(gpk->p);pfc.add_to_hash(gpk->g1);pfc.add_to_hash(gpk->g2);pfc.add_to_hash(gpk->g3);
-    //  pfc.add_to_hash(gpk->h1);pfc.add_to_hash(gpk->h2);pfc.add_to_hash(gpk->w);
-    //  pfc.add_to_hash(B);pfc.add_to_hash(K);pfc.add_to_hash(PoK);
-    //  cbk = pfc.finish_hash_to_group();
+    //  platformPFC->random(rbkf);
+    //  PoK=platformPFC->mult(B,rbkf);
+    //  platformPFC->start_hash();
+    //  platformPFC->add_to_hash(gpk->p);platformPFC->add_to_hash(gpk->g1);platformPFC->add_to_hash(gpk->g2);platformPFC->add_to_hash(gpk->g3);
+    //  platformPFC->add_to_hash(gpk->h1);platformPFC->add_to_hash(gpk->h2);platformPFC->add_to_hash(gpk->w);
+    //  platformPFC->add_to_hash(B);platformPFC->add_to_hash(K);platformPFC->add_to_hash(PoK);
+    //  cbk = platformPFC->finish_hash_to_group();
     //  sbkf = (rbkf+modmult(cbk,f,gpk->p))%gpk->p;
 
     // BK *bk = (BK*)malloc(sizeof(BK));
@@ -210,5 +186,8 @@ Sigma *platformSign(GPK *gpk, char *m, SRL *sRL)
     // bk->c = cbk;
     // bk->sf = sbkf;
 
-    return sigma;
+}
+
+SK* platformLeakSK_Test(){
+    return sk;
 }

--- a/epid_role/epid_platform.h
+++ b/epid_role/epid_platform.h
@@ -1,16 +1,60 @@
 #ifndef EPID_PLATFORM
 #define EPID_PLATFORM
 
-#define MR_PAIRING_BN    // AES-128 or AES-192 security
-#define AES_SECURITY 128
+// #define MR_PAIRING_BN    // AES-128 or AES-192 security
+// #define AES_SECURITY 128
 
-#include "pairing_3.h"
+// #include "pairing_3.h"
 #include "epid_type.h"
+
+// platform & revoker
+struct SK{
+    G1 A;
+    Big x,y,f;
+};
+
+// platform & issuer
+struct Platform_CommC{
+    G1 C;
+    Big c,sf,sy1;
+};
+
+// platform & issuer
+struct Platform_CRE{
+    G1 A;
+    Big x,y2;
+};
+
+// SigmaiNode
+struct Platform_BK_SPK{
+    G3 B,K;
+    Big c,sf;
+};
+
+// platform & verifier & revoker
+struct Platform_Sigma0{
+    G3 B,K;
+    G1 T;
+    Big c,sf,sx,sa,sb;
+};
+
+struct Platform_Sigmai{
+    Platform_BK_SPK *sigmai;
+    int cnt;
+};
+
+// platform & verifier & revoker
+struct Platform_Sigma{
+    Platform_Sigma0 *sigma0;
+    Platform_Sigmai *sigmai;
+};
 
 void platformInit();
 void platformPreCom();
-CommC* platformJoin_1(GPK *gpk);
-PPK* platformJoin_3(GPK *gpk, CRE *cre);
-Sigma* platformSign(GPK *gpk, char *m,SRL *sRL);
+void platformJoin_1(GPK *gpk,Platform_CommC* commC);
+int platformJoin_3(GPK *gpk, Platform_CRE *cre, PPK *ppk);
+void platformSign(GPK *gpk, char *m, Public_SRL *sRL, Platform_Sigma* sigma);
+
+SK* platformLeakSK_Test();
 
 #endif

--- a/epid_role/epid_revoker.cpp
+++ b/epid_role/epid_revoker.cpp
@@ -1,64 +1,114 @@
 #include "epid_revoker.h"
 
 GT rt1,rt2,rt3,rt4;
+SRL *sRL;
+PRL *pRL;
+PFC *revokerPFC = &pfc;
 
-void revokerPreCom()
-{
-    pfc.precomp_for_power(rt1);
-    pfc.precomp_for_power(rt2);
-    pfc.precomp_for_power(rt3);
-    pfc.precomp_for_power(rt4);
-}
-void revokerCheckPRL(PRL *pRL, G3 *B, G3 *K){
+void setPRL(Public_PRL *pPRL){    
     PRLNode *p = pRL->head;
-    while(p!=NULL){
-        if(*K==pfc.mult(*B,p->f)){
-            cout << "pRL revoked! " << endl;
-            exit(0);
-        }
+    int c;
+    if(p != nullptr){
+        c = 1;
+    }else{return;}
+    while(p->next){
+        c++;
         p = p->next;
     }
+    p = pRL->head;
+    delete(pPRL->f);
+    pPRL->f = new Big[c];
+    for(int i=0;i<c;i++){
+        pPRL->f[i] = p->f;
+        p = p->next;
+    }
+    pPRL->cnt = c;
 }
 
-void revokerCheckSRL(GPK *gpk, char *m, Sigmai *sigmai, G3 *B, G3 *K){
-    BK_SPK *s=sigmai->head;
-    while(s!=NULL){
-        G3 R = pfc.mult(*B,s->sf)+pfc.mult(*K,(-1) * s->c);
-        G3 Ri = pfc.mult(s->B,s->sf)+pfc.mult(s->K,(-1)*s->c);
-        pfc.start_hash();
-        pfc.add_to_hash(gpk->p);
-        pfc.add_to_hash(gpk->g1);
-        pfc.add_to_hash(gpk->g2);
-        pfc.add_to_hash(gpk->g3);
-        pfc.add_to_hash(gpk->h1);
-        pfc.add_to_hash(gpk->h2);
-        pfc.add_to_hash(gpk->w);
-        pfc.add_to_hash(*B);
-        pfc.add_to_hash(*K);
-        pfc.add_to_hash(R);
-        pfc.add_to_hash(s->B);
-        pfc.add_to_hash(s->K);
-        pfc.add_to_hash(Ri);
-        pfc.add_to_hash(m);
-        Big c = pfc.finish_hash_to_group();
+void setSRL(Public_SRL *pSRL){
+    BK *q = sRL->head;
+    int c;
+    if(q != nullptr){
+        c = 1;
+    }else{return;}
+    while(q->next){
+        c++;
+        q = q->next;
+    }
+    q = sRL->head;
+    delete(pSRL->sRLNode);
+    pSRL->sRLNode = new Public_SRLNode[c];
+    for(int i=0;i<c;i++){
+        pSRL->sRLNode[i].B = q->B;
+        pSRL->sRLNode[i].K = q->K;
+    }
+    pSRL->cnt = c;
+}
+
+void revokerPreCom(Public_PRL *pPRL, Public_SRL *pSRL)
+{
+    // revokerPFC = PFC(AES_SECURITY);
+    pRL = new PRL();
+    sRL = new SRL();
+
+    revokerPFC->precomp_for_power(rt1);
+    revokerPFC->precomp_for_power(rt2);
+    revokerPFC->precomp_for_power(rt3);
+    revokerPFC->precomp_for_power(rt4);
+
+    setPRL(pPRL);
+    setSRL(pSRL);
+}
+
+int revokerCheckPRL(Public_PRL *pRL, G3 *B, G3 *K){
+    for(int i=0;i<pRL->cnt;i++){
+        if(*K==revokerPFC->mult(*B,pRL->f[i])){
+            cout << "pRL revoked! " << endl;
+            return -1;
+        }
+    }
+    return 0;
+}
+
+int revokerCheckSRL(GPK *gpk, char *m, Revoker_Sigmai *sigmai, G3 *B, G3 *K){
+    for(int i=0;i<sigmai->cnt;i++){
+        Revoker_BK_SPK *s = &(sigmai->sigmai[i]);
+        G3 R = revokerPFC->mult(*B,s->sf)+revokerPFC->mult(*K,(-1) * s->c);
+        G3 Ri = revokerPFC->mult(s->B,s->sf)+revokerPFC->mult(s->K,(-1)*s->c);
+        revokerPFC->start_hash();
+        revokerPFC->add_to_hash(gpk->p);
+        revokerPFC->add_to_hash(gpk->g1);
+        revokerPFC->add_to_hash(gpk->g2);
+        revokerPFC->add_to_hash(gpk->g3);
+        revokerPFC->add_to_hash(gpk->h1);
+        revokerPFC->add_to_hash(gpk->h2);
+        revokerPFC->add_to_hash(gpk->w);
+        revokerPFC->add_to_hash(*B);
+        revokerPFC->add_to_hash(*K);
+        revokerPFC->add_to_hash(R);
+        revokerPFC->add_to_hash(s->B);
+        revokerPFC->add_to_hash(s->K);
+        revokerPFC->add_to_hash(Ri);
+        revokerPFC->add_to_hash(m);
+        Big c = revokerPFC->finish_hash_to_group();
         if(c == s->c){
             cout << "sRL revoked! " << endl;
-            exit(0);
+            return -1;
         }
-        s = s->next;
     }
+    return 0;
 }
 
-void revokerRevokePRL(GPK *gpk, PRL *pRL, SK *sk){
-    G2 wxg2 = gpk->w + pfc.mult(gpk->g2, sk->x);
-    G1 g1h1fh2y = -(pfc.mult(gpk->h1, sk->f) + pfc.mult(gpk->h2, sk->y) + gpk->g1);
+void revokerRevokePRL(GPK *gpk, Public_PRL *pPRL, Revoker_SK *sk){
+    G2 wxg2 = gpk->w + revokerPFC->mult(gpk->g2, sk->x);
+    G1 g1h1fh2y = -(revokerPFC->mult(gpk->h1, sk->f) + revokerPFC->mult(gpk->h2, sk->y) + gpk->g1);
     G1 *e1[2];
     G2 *e2[2];
     e1[0] = &sk->A;
     e1[1] = &g1h1fh2y;
     e2[0] = &wxg2;
     e2[1] = &gpk->g2;
-    if (pfc.multi_pairing(2, e2, e1) != 1)
+    if (revokerPFC->multi_pairing(2, e2, e1) != 1)
     {
         cout << "Pairing verification failed, aborting.. " << endl;
         exit(0);
@@ -67,48 +117,62 @@ void revokerRevokePRL(GPK *gpk, PRL *pRL, SK *sk){
     // PRLNode *tmp = (PRLNode*)malloc(sizeof(PRLNode));
     PRLNode *tmp = new PRLNode();
     tmp->f = sk->f;
-    pRL->tail->next = tmp;
+    if(pRL->head==NULL){
+        pRL->head = tmp;
+    }else{
+        pRL->tail->next = tmp;
+    }
     pRL->tail = tmp;
+
+    setPRL(pPRL);
 }
-void revokerRevokeSRL(GPK *gpk, PRL *pRL, SRL *sRL, char *m, Sigma *sigma){
-    revokerVerify(gpk,m,pRL,sigma->sigmai,sigma->sigma0);
+int revokerRevokeSRL(GPK *gpk, Public_PRL *pPRL, Public_SRL *pSRL, char *m, Revoker_Sigma *sigma){
+    if(revokerVerify(gpk,m,pPRL,sigma->sigmai,sigma->sigma0))return -1;
     // BK *tmp = (BK*)malloc(sizeof(BK));
     BK *tmp = new BK();
     tmp->B = sigma->sigma0->B;
     tmp->K = sigma->sigma0->K;
-    sRL->tail->next = tmp;
+    if(sRL->head==NULL){
+        sRL->head = tmp;
+    }else{
+        sRL->tail->next = tmp;
+    }
     sRL->tail = tmp;
+
+    setSRL(pSRL);
+    return 0;
 }
 
-void revokerVerify(GPK *gpk, char *m, PRL *pRL, Sigmai *sigmai, Sigma0 *sigma0)
+int revokerVerify(GPK *gpk, char *m, Public_PRL *pPRL, Revoker_Sigmai *sigmai, Revoker_Sigma0 *sigma0)
 {
     // 验证sigma0的知识证明
-    G3 R1 = pfc.mult(sigma0->B, sigma0->sf) + pfc.mult(sigma0->K, (-1) * sigma0->c);
-    GT R2 = pfc.pairing(pfc.mult(gpk->g2, (-1) * sigma0->sx) + pfc.mult(gpk->w, (-1) * sigma0->c), sigma0->T) * pfc.power(rt2, sigma0->sf) * pfc.power(rt3, sigma0->sb) * pfc.power(rt4, sigma0->sa) * pfc.power(rt1, sigma0->c);
-    pfc.start_hash();
-    pfc.add_to_hash(gpk->p);
-    pfc.add_to_hash(gpk->g1);
-    pfc.add_to_hash(gpk->g2);
-    pfc.add_to_hash(gpk->g3);
-    pfc.add_to_hash(gpk->h1);
-    pfc.add_to_hash(gpk->h2);
-    pfc.add_to_hash(gpk->w);
-    pfc.add_to_hash(sigma0->B);
-    pfc.add_to_hash(sigma0->K);
-    pfc.add_to_hash(sigma0->T);
-    pfc.add_to_hash(R1);
-    pfc.add_to_hash(R2);
-    pfc.add_to_hash(m);
-    Big c = pfc.finish_hash_to_group();
+    G3 R1 = revokerPFC->mult(sigma0->B, sigma0->sf) + revokerPFC->mult(sigma0->K, (-1) * sigma0->c);
+    GT R2 = revokerPFC->pairing(revokerPFC->mult(gpk->g2, (-1) * sigma0->sx) + revokerPFC->mult(gpk->w, (-1) * sigma0->c), sigma0->T) * revokerPFC->power(rt2, sigma0->sf) * revokerPFC->power(rt3, sigma0->sb) * revokerPFC->power(rt4, sigma0->sa) * revokerPFC->power(rt1, sigma0->c);
+    revokerPFC->start_hash();
+    revokerPFC->add_to_hash(gpk->p);
+    revokerPFC->add_to_hash(gpk->g1);
+    revokerPFC->add_to_hash(gpk->g2);
+    revokerPFC->add_to_hash(gpk->g3);
+    revokerPFC->add_to_hash(gpk->h1);
+    revokerPFC->add_to_hash(gpk->h2);
+    revokerPFC->add_to_hash(gpk->w);
+    revokerPFC->add_to_hash(sigma0->B);
+    revokerPFC->add_to_hash(sigma0->K);
+    revokerPFC->add_to_hash(sigma0->T);
+    revokerPFC->add_to_hash(R1);
+    revokerPFC->add_to_hash(R2);
+    revokerPFC->add_to_hash(m);
+    Big c = revokerPFC->finish_hash_to_group();
 
     if (c != sigma0->c)
     {
-        cout << "Verification failed, aborting.. " << endl;
-        exit(0);
+        cout << " Revoker verification failed, aborting.. " << endl;
+        return -1;
     }
 //检查pRL和sRL
-    revokerCheckPRL(pRL, &sigma0->B, &sigma0->K);
-    revokerCheckSRL(gpk, m, sigmai, &sigma0->B, &sigma0->K);
+    if(revokerCheckPRL(pPRL, &sigma0->B, &sigma0->K))return -1;
+    if(revokerCheckSRL(gpk, m, sigmai, &sigma0->B, &sigma0->K))return -1;
 
-    cout << "Verification succeeds! " << endl;
+    cout << "Revoker verification succeeds! " << endl;
+    return 0;
 }

--- a/epid_role/epid_revoker.h
+++ b/epid_role/epid_revoker.h
@@ -1,19 +1,73 @@
 #ifndef EPID_REVOKER
 #define EPID_REVOKER
 
-#define MR_PAIRING_BN    // AES-128 or AES-192 security
-#define AES_SECURITY 128
+// #define MR_PAIRING_BN    // AES-128 or AES-192 security
+// #define AES_SECURITY 128
 
-#include "pairing_3.h"
+// #include "pairing_3.h"
 #include "epid_type.h"
 
-void revokerPreCom();
-void revokerVerify(GPK * gpk, char *m, PRL *pRL, Sigmai *sigmai, Sigma0 *sigma0);
+// platform & verifier & revoker
+struct PRLNode{
+    Big f;
+    PRLNode *next;
+};
 
-void revokerCheckPRL(PRL *pRL, G3 *B, G3 *K);
-void revokerCheckSRL(GPK *gpk, char *m, Sigmai *sigmai, G3 *B, G3 *K);
+// platform & verifier & revoker
+struct PRL{
+    PRLNode *head;
+    PRLNode *tail;
+};
 
-void revokerRevokePRL(GPK *gpk, PRL *pRL, SK *sk);
-void revokerRevokeSRL(GPK *gpk, PRL *pRL, SRL *sRL, char *m, Sigma *sigma);
+// SRLNode
+struct BK{
+    G3 B,K;
+    BK *next;
+};
+
+// platform & verifier & revoker
+struct SRL{
+    BK *head;
+    BK *tail;
+};
+
+// platform & revoker
+struct Revoker_SK{
+    G1 A;
+    Big x,y,f;
+};
+
+// SigmaiNode
+struct Revoker_BK_SPK{
+    G3 B,K;
+    Big c,sf;
+};
+
+// platform & verifier & revoker
+struct Revoker_Sigma0{
+    G3 B,K;
+    G1 T;
+    Big c,sf,sx,sa,sb;
+};
+
+struct Revoker_Sigmai{
+    Revoker_BK_SPK *sigmai;
+    int cnt;
+};
+
+// platform & verifier & revoker
+struct Revoker_Sigma{
+    Revoker_Sigma0 *sigma0;
+    Revoker_Sigmai *sigmai;
+};
+
+void revokerPreCom(Public_PRL *pPRL, Public_SRL *pSRL);
+int revokerVerify(GPK * gpk, char *m, Public_PRL *pRL, Revoker_Sigmai *sigmai, Revoker_Sigma0 *sigma0);
+
+int revokerCheckPRL(PRL *pRL, G3 *B, G3 *K);
+int revokerCheckSRL(GPK *gpk, char *m, Revoker_Sigmai *sigmai, G3 *B, G3 *K);
+
+void revokerRevokePRL(GPK *gpk, Public_PRL *pRL, Revoker_SK *sk);
+int revokerRevokeSRL(GPK *gpk, Public_PRL *pRL, Public_SRL *sRL, char *m, Revoker_Sigma *sigma);
 
 #endif

--- a/epid_role/epid_type.h
+++ b/epid_role/epid_type.h
@@ -10,6 +10,7 @@ extern PFC pfc;  // initialise pairing-friendly curve
 
 typedef G1 G3;
 
+// public
 struct GPK{//群公钥
     Big p;
     G1 g1, h1, h2;
@@ -17,71 +18,24 @@ struct GPK{//群公钥
     G3 g3;
 };
 
-struct SK{
-    G1 A;
-    Big x,y,f;
-};
-
+// public
 struct PPK{
     G1 A;
     Big x,y;
 };
 
-struct CommC{
-    G1 C;
-    Big c,sf,sy1;
-};
-
-struct CRE{
-    G1 A;
-    Big x,y2;
-};
-
-struct BK{
+struct Public_SRLNode{
     G3 B,K;
-    BK *next;
 };
 
-struct SRL{
-    BK *head;
-    BK *tail;
+struct Public_SRL{
+    Public_SRLNode *sRLNode;
+    int cnt;
 };
 
-struct BK_SPK{
-    G3 B,K;
-    Big c,sf;
-    BK_SPK *next;
-};
-
-struct Sigma0{
-    G3 B,K;
-    G1 T;
-    Big c,sf,sx,sa,sb;
-};
-
-struct Sigmai{
-    BK_SPK *head;
-    BK_SPK *tail;
-};
-
-struct Sigma{
-    Sigma0 *sigma0;
-    Sigmai *sigmai;
-};
-
-struct PRLNode{
-    Big f;
-    PRLNode *next;
-};
-
-struct PRL{
-    PRLNode *head;
-    PRLNode *tail;
-};
-
-struct public_PRL{
-    PRLNode *p;
-    uint32 cnt;
+struct Public_PRL{
+    Big *f;
+    int cnt;
 };
 
 #endif

--- a/epid_role/epid_verifier.cpp
+++ b/epid_role/epid_verifier.cpp
@@ -1,84 +1,87 @@
 #include "epid_verifier.h"
 
 GT vt1,vt2,vt3,vt4;
-
+PFC *verifierPFC=&pfc;
 void verifierPreCom()
 {
-    pfc.precomp_for_power(vt1);
-    pfc.precomp_for_power(vt2);
-    pfc.precomp_for_power(vt3);
-    pfc.precomp_for_power(vt4);
+    // verifierPFC = PFC(AES_SECURITY);
+
+    verifierPFC->precomp_for_power(vt1);
+    verifierPFC->precomp_for_power(vt2);
+    verifierPFC->precomp_for_power(vt3);
+    verifierPFC->precomp_for_power(vt4);
 }
 
-void verifierVerify(GPK *gpk, char *m, PRL *pRL, Sigmai *sigmai, Sigma0 *sigma0)
+int verifierCheckPRL(Public_PRL *pRL, G3 *B, G3 *K){
+    for(int i=0;i<pRL->cnt;i++){
+        if(*K==verifierPFC->mult(*B,pRL->f[i])){
+            cout << "pRL revoked! " << endl;
+            return -1;
+        }
+    }
+    return 0;
+}
+
+int verifierCheckSRL(GPK *gpk, char *m, Verifier_Sigmai *sigmai, G3 *B, G3 *K){
+    for(int i=0;i<sigmai->cnt;i++){
+        Verifier_BK_SPK *s = &(sigmai->sigmai[i]);
+        G3 R = verifierPFC->mult(*B,s->sf)+verifierPFC->mult(*K,(-1) * s->c);
+        G3 Ri = verifierPFC->mult(s->B,s->sf)+verifierPFC->mult(s->K,(-1)*s->c);
+        verifierPFC->start_hash();
+        verifierPFC->add_to_hash(gpk->p);
+        verifierPFC->add_to_hash(gpk->g1);
+        verifierPFC->add_to_hash(gpk->g2);
+        verifierPFC->add_to_hash(gpk->g3);
+        verifierPFC->add_to_hash(gpk->h1);
+        verifierPFC->add_to_hash(gpk->h2);
+        verifierPFC->add_to_hash(gpk->w);
+        verifierPFC->add_to_hash(*B);
+        verifierPFC->add_to_hash(*K);
+        verifierPFC->add_to_hash(R);
+        verifierPFC->add_to_hash(s->B);
+        verifierPFC->add_to_hash(s->K);
+        verifierPFC->add_to_hash(Ri);
+        verifierPFC->add_to_hash(m);
+        Big c = verifierPFC->finish_hash_to_group();
+        if(c == s->c){
+            cout << "sRL revoked! " << endl;
+            return -1;
+        }
+    }
+    return 0;
+}
+
+int verifierVerify(GPK *gpk, char *m, Public_PRL *pRL, Verifier_Sigmai *sigmai, Verifier_Sigma0 *sigma0)
 {
     // 验证sigma0的知识证明
-    G3 R1 = pfc.mult(sigma0->B, sigma0->sf) + pfc.mult(sigma0->K, (-1) * sigma0->c);
-    GT R2 = pfc.pairing(pfc.mult(gpk->g2, (-1) * sigma0->sx) + pfc.mult(gpk->w, (-1) * sigma0->c), sigma0->T) * pfc.power(vt2, sigma0->sf) * pfc.power(vt3, sigma0->sb) * pfc.power(vt4, sigma0->sa) * pfc.power(vt1, sigma0->c);
-    pfc.start_hash();
-    pfc.add_to_hash(gpk->p);
-    pfc.add_to_hash(gpk->g1);
-    pfc.add_to_hash(gpk->g2);
-    pfc.add_to_hash(gpk->g3);
-    pfc.add_to_hash(gpk->h1);
-    pfc.add_to_hash(gpk->h2);
-    pfc.add_to_hash(gpk->w);
-    pfc.add_to_hash(sigma0->B);
-    pfc.add_to_hash(sigma0->K);
-    pfc.add_to_hash(sigma0->T);
-    pfc.add_to_hash(R1);
-    pfc.add_to_hash(R2);
-    pfc.add_to_hash(m);
-    Big c = pfc.finish_hash_to_group();
+    G3 R1 = verifierPFC->mult(sigma0->B, sigma0->sf) + verifierPFC->mult(sigma0->K, (-1) * sigma0->c);
+    GT R2 = verifierPFC->pairing(verifierPFC->mult(gpk->g2, (-1) * sigma0->sx) + verifierPFC->mult(gpk->w, (-1) * sigma0->c), sigma0->T) * verifierPFC->power(vt2, sigma0->sf) * verifierPFC->power(vt3, sigma0->sb) * verifierPFC->power(vt4, sigma0->sa) * verifierPFC->power(vt1, sigma0->c);
+    verifierPFC->start_hash();
+    verifierPFC->add_to_hash(gpk->p);
+    verifierPFC->add_to_hash(gpk->g1);
+    verifierPFC->add_to_hash(gpk->g2);
+    verifierPFC->add_to_hash(gpk->g3);
+    verifierPFC->add_to_hash(gpk->h1);
+    verifierPFC->add_to_hash(gpk->h2);
+    verifierPFC->add_to_hash(gpk->w);
+    verifierPFC->add_to_hash(sigma0->B);
+    verifierPFC->add_to_hash(sigma0->K);
+    verifierPFC->add_to_hash(sigma0->T);
+    verifierPFC->add_to_hash(R1);
+    verifierPFC->add_to_hash(R2);
+    verifierPFC->add_to_hash(m);
+    Big c = verifierPFC->finish_hash_to_group();
 
     if (c != sigma0->c)
     {
         cout << "Verification failed, aborting.. " << endl;
-        exit(0);
+        return -1;
     }
 //检查pRL和sRL
-    verifierCheckPRL(pRL, &sigma0->B, &sigma0->K);
-    verifierCheckSRL(gpk, m, sigmai, &sigma0->B, &sigma0->K);
+    if(verifierCheckPRL(pRL, &sigma0->B, &sigma0->K))return -1;
+    if(verifierCheckSRL(gpk, m, sigmai, &sigma0->B, &sigma0->K))return -1;
 
     cout << "Verification succeeds! " << endl;
-}
 
-void verifierCheckPRL(PRL *pRL, G3 *B, G3 *K){
-    PRLNode *p = pRL->head;
-    while(p!=NULL){
-        if(*K==pfc.mult(*B,p->f)){
-            cout << "pRL revoked! " << endl;
-            exit(0);
-        }
-        p = p->next;
-    }
-}
-
-void verifierCheckSRL(GPK *gpk, char *m, Sigmai *sigmai, G3 *B, G3 *K){
-    BK_SPK *s=sigmai->head;
-    while(s!=NULL){
-        G3 R = pfc.mult(*B,s->sf)+pfc.mult(*K,(-1) * s->c);
-        G3 Ri = pfc.mult(s->B,s->sf)+pfc.mult(s->K,(-1)*s->c);
-        pfc.start_hash();
-        pfc.add_to_hash(gpk->p);
-        pfc.add_to_hash(gpk->g1);
-        pfc.add_to_hash(gpk->g2);
-        pfc.add_to_hash(gpk->g3);
-        pfc.add_to_hash(gpk->h1);
-        pfc.add_to_hash(gpk->h2);
-        pfc.add_to_hash(gpk->w);
-        pfc.add_to_hash(*B);
-        pfc.add_to_hash(*K);
-        pfc.add_to_hash(R);
-        pfc.add_to_hash(s->B);
-        pfc.add_to_hash(s->K);
-        pfc.add_to_hash(Ri);
-        pfc.add_to_hash(m);
-        Big c = pfc.finish_hash_to_group();
-        if(c == s->c){
-            cout << "sRL revoked! " << endl;
-            exit(0);
-        }
-        s = s->next;
-    }
+    return 0;
 }

--- a/epid_role/epid_verifier.h
+++ b/epid_role/epid_verifier.h
@@ -1,16 +1,40 @@
 #ifndef EPID_VERIFIER
 #define EPID_VERIFIER
 
-#define MR_PAIRING_BN    // AES-128 or AES-192 security
-#define AES_SECURITY 128
-
-#include "pairing_3.h"
 #include "epid_type.h"
 
-void verifierCheckPRL(PRL *pRL, G3 *B, G3 *K);
-void verifierCheckSRL(GPK *gpk, char *m, Sigmai *sigmai, G3 *B, G3 *K);
+// #define MR_PAIRING_BN    // AES-128 or AES-192 security
+// #define AES_SECURITY 128
+
+
+// SigmaiNode
+struct Verifier_BK_SPK{
+    G3 B,K;
+    Big c,sf;
+};
+
+// platform & verifier & revoker
+struct Verifier_Sigma0{
+    G3 B,K;
+    G1 T;
+    Big c,sf,sx,sa,sb;
+};
+
+struct Verifier_Sigmai{
+    Verifier_BK_SPK *sigmai;
+    int cnt;
+};
+
+// platform & verifier & revoker
+struct Verifier_Sigma{
+    Verifier_Sigma0 *sigma0;
+    Verifier_Sigmai *sigmai;
+};
+
+int verifierCheckPRL(Public_PRL *pRL, G3 *B, G3 *K);
+int verifierCheckSRL(GPK *gpk, char *m, Verifier_Sigmai *sigmai, G3 *B, G3 *K);
 
 void verifierPreCom();
-void verifierVerify(GPK * gpk, char *m, PRL *pRL, Sigmai *sigmai, Sigma0 *sigma0);
+int verifierVerify(GPK * gpk, char *m, Public_PRL *pRL, Verifier_Sigmai *sigmai, Verifier_Sigma0 *sigma0);
 
 #endif


### PR DESCRIPTION
添加反例测试,将传递内容的初始化分离出来,使用公共的撤销列表以固定长度,结构体针对角色分离简化epid_type.h,各角色使用自己的pfc(暂时使用别名替代)